### PR TITLE
fix: superclass RainbowAgent does not have `min_q_weight` in its __init__.

### DIFF
--- a/atari/batch_rl/multi_head/quantile_agent.py
+++ b/atari/batch_rl/multi_head/quantile_agent.py
@@ -113,8 +113,7 @@ class QuantileAgent(rainbow_agent.RainbowAgent):
         tf_device=tf_device,
         optimizer=optimizer,
         summary_writer=summary_writer,
-        summary_writing_frequency=summary_writing_frequency,
-        min_q_weight=minq_weight)
+        summary_writing_frequency=summary_writing_frequency)
     
     self.minq_weight = minq_weight
     print ('min Q weight (QR-DQN): ', self.minq_weight)


### PR DESCRIPTION


I don't know what version of Dopamine you are using, but the superclass [RainbowAgent](https://github.com/google/dopamine/blob/0db8d0697029fbe2d59fe36e6ecc7cff76081ab5/dopamine/agents/rainbow/rainbow_agent.py#L51) does not have `min_q_weight` in its constructor.

This will cause an error running your example command:
```txt
TypeError: __init__() got an unexpected keyword argument 'min_q_weight'
  In call to configurable 'RainbowAgent' (<class 'dopamine.agents.rainbow.rainbow_agent.RainbowAgent'>)
  In call to configurable 'QuantileAgent' (<class 'batch_rl.multi_head.quantile_agent.QuantileAgent'>)
  In call to configurable 'FixedReplayQuantileAgent' (<class 'batch_rl.fixed_replay.agents.quantile_agent.FixedReplayQuantileAgent'>)
  In call to configurable 'Runner' (<class 'dopamine.discrete_domains.run_experiment.Runner'>)
  In call to configurable 'FixedReplayRunner' (<class 'batch_rl.fixed_replay.run_experiment.FixedReplayRunner'>)
```